### PR TITLE
Include sys/malloc.h on apple

### DIFF
--- a/ext/ansible.c
+++ b/ext/ansible.c
@@ -1,5 +1,9 @@
 #include <stdio.h>
+#ifdef __APPLE__
+#include <sys/malloc.h>
+#else
 #include <malloc.h>
+#endif
 #include <stdbool.h>
 #include <ruby.h>
 #include <ruby/encoding.h>


### PR DESCRIPTION
On OSX 10.7, llvm-gcc-4.2, installing the gem output:

```

[c-extension][~/dev/ansible] rake build
ansible 0.5.0 built to pkg/ansible-0.5.0.gem

[c-extension][~/dev/ansible] gem install pkg/ansible-0.5.0.gem 
Building native extensions.  This could take a while...
ERROR:  Error installing pkg/ansible-0.5.0.gem:
    ERROR: Failed to build gem native extension.

        /Users/jason/.rvm/rubies/ruby-1.9.2-p290/bin/ruby extconf.rb
checking for stdio.h... yes
creating Makefile

make
gcc -I. -I/Users/jason/.rvm/rubies/ruby-1.9.2-p290/include/ruby-1.9.1/x86_64-darwin11.0.1 -I/Users/jason/.rvm/rubies/ruby-1.9.2-p290/include/ruby-1.9.1/ruby/backward -I/Users/jason/.rvm/rubies/ruby-1.9.2-p290/include/ruby-1.9.1 -I. -DHAVE_STDIO_H -D_XOPEN_SOURCE -D_DARWIN_C_SOURCE   -fno-common -Wall -O3  -o ansible.o -c ansible.c
ansible.c:2:20: error: malloc.h: No such file or directory
make: *** [ansible.o] Error 1


Gem files will remain installed in /Users/jason/.rvm/gems/ruby-1.9.2-p290/gems/ansible-0.5.0 for inspection.
Results logged to /Users/jason/.rvm/gems/ruby-1.9.2-p290/gems/ansible-0.5.0/ext/gem_make.out
```

With this change, I can install and run `rake spec` successfully.
