### PR TITLE
Merge multiple escapes together

### DIFF
--- a/lib/ansible.rb
+++ b/lib/ansible.rb
@@ -1,5 +1,6 @@
 module Ansible
   def escape_to_html(data)
+    data.gsub!(/m\e\[/, ';')
     data = span(true, "none") + data
     data.gsub!(/\e\[0?m/, span(false, "none"))
     data.gsub!(/\e\[([0-9;]+)m/) { |match|


### PR DESCRIPTION
`\e\[1m\e\[33m Test2` becomes `\e\[1;33m Test2`
